### PR TITLE
Reimplemented Intersection type family

### DIFF
--- a/src/Data/Type/List.hs
+++ b/src/Data/Type/List.hs
@@ -164,8 +164,9 @@ type instance Apply (Find' x) xs = Find x xs
 -- | Type list intersection. 
 type family Intersection xs ys where
     Intersection '[] ys = '[]
-    Intersection (x ': xs) (x ': ys) = x ': (Intersection xs ys)
-    Intersection (x ': xs) (y ': ys) = If (Find x ys) (x ': (Intersection xs (y ': ys))) (Intersection xs (y ': ys))
+    Intersection (x ': xs) ys = If (Find x ys)
+                                   (x ': Intersection xs ys)
+                                   (Intersection xs ys)
 
 data Intersection'' :: TyFun [k] (TyFun [k] [k] -> *) -> * where
     Intersection'' :: Intersection'' f


### PR DESCRIPTION
Hi,

it seems that the current implementation of the Intersection type family is bogus. For instance:

*Data.Type.List> :t (Proxy :: Proxy (Intersection '[Int] '[]))
(Proxy :: Proxy (Intersection '[Int] '[]))
  :: Proxy (Intersection '[Int] '[])
*Data.Type.List> 

Whereas with this PR we have:

*Data.Type.List> :t (Proxy :: Proxy (Intersection '[Int] '[]))
(Proxy :: Proxy (Intersection '[Int] '[])) :: Proxy '[]
*Data.Type.List> 
